### PR TITLE
Return 404 when not found

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -28,6 +28,7 @@ const (
 	ErrorTypeRuntimeException         = "runtime_exception"
 	ErrorTypeNotImplemented           = "not_implemented"
 	ErrorTypeInvalidArgument          = "invalid_argument"
+	ErrorIndexNotFound                = "index_not_found"
 )
 
 var ErrorIDNotFound = errors.New("id not found")

--- a/pkg/errors/http.go
+++ b/pkg/errors/http.go
@@ -25,7 +25,12 @@ func HandleError(c *gin.Context, err error) {
 	if err != nil {
 		switch v := err.(type) {
 		case *Error:
-			c.JSON(http.StatusBadRequest, gin.H{"error": v})
+			switch v.Type {
+			case ErrorIndexNotFound:
+				c.JSON(http.StatusNotFound, gin.H{"error": v})
+			default:
+				c.JSON(http.StatusBadRequest, gin.H{"error": v})
+			}
 		default:
 			c.JSON(http.StatusBadRequest, gin.H{"error": v.Error()})
 		}

--- a/pkg/handlers/search/search_v2.go
+++ b/pkg/handlers/search/search_v2.go
@@ -186,7 +186,7 @@ func searchIndex(indexNames []string, query *meta.ZincQuery) (*meta.SearchRespon
 	} else {
 		index, exists := core.GetIndex(indexName)
 		if !exists {
-			return nil, fmt.Errorf("index %s does not exists", indexName)
+			return nil, errors.New(errors.ErrorIndexNotFound, fmt.Sprintf("index %s does not exists", indexName))
 		}
 		resp, err = index.Search(query)
 	}

--- a/test/api/search_v2_test.go
+++ b/test/api/search_v2_test.go
@@ -43,7 +43,7 @@ func TestSearchV2(t *testing.T) {
 			body := bytes.NewBuffer(nil)
 			body.WriteString(`{}`)
 			resp := request("POST", "/es/notExistSearch/_search", body)
-			assert.Equal(t, http.StatusBadRequest, resp.Code)
+			assert.Equal(t, http.StatusNotFound, resp.Code)
 		})
 		t.Run("search document with exist indexName", func(t *testing.T) {
 			body := bytes.NewBuffer(nil)
@@ -187,6 +187,21 @@ func TestSearchV2(t *testing.T) {
 			err := json.Unmarshal(resp.Body.Bytes(), data)
 			assert.NoError(t, err)
 			assert.GreaterOrEqual(t, data.Hits.Total.Value, 1)
+		})
+	})
+
+	t.Run("POST /es/:target/_count", func(t *testing.T) {
+		t.Run("count document with not exist indexName", func(t *testing.T) {
+			body := bytes.NewBuffer(nil)
+			body.WriteString(`{}`)
+			resp := request("POST", "/es/notExistcount/_count", body)
+			assert.Equal(t, http.StatusNotFound, resp.Code)
+		})
+		t.Run("count document with exist indexName", func(t *testing.T) {
+			body := bytes.NewBuffer(nil)
+			body.WriteString(`{"query": {"match_all":{}}, "size":10}`)
+			resp := request("POST", "/es/"+indexName+"/_count", body)
+			assert.Equal(t, http.StatusOK, resp.Code)
 		})
 	})
 


### PR DESCRIPTION
Return 404 when document is not found on search and count routes (ES behaves like that).